### PR TITLE
better handling of vertical dims

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -180,6 +180,7 @@ const COORD_ATTRS = Dict(
         "positive"         => "up",
         "long_name"        => "height above the surface",
         "standard_name"    => "height",
+        "axis"             => "Z"
     ),
     "isobaricInhPa"        => Dict(
         "units"            => "hPa",
@@ -187,6 +188,7 @@ const COORD_ATTRS = Dict(
         "stored_direction" => "decreasing",
         "standard_name"    => "air_pressure",
         "long_name"        => "pressure",
+        "axis"             => "Z",
     ),
     "isobaricInPa"         => Dict(
         "units"            => "Pa",
@@ -194,6 +196,7 @@ const COORD_ATTRS = Dict(
         "stored_direction" => "decreasing",
         "standard_name"    => "air_pressure",
         "long_name"        => "pressure",
+        "axis"             => "Z",
     ),
     "isobaricLayer"        => Dict(
         "units"            => "Pa",
@@ -249,4 +252,20 @@ const GRID_TYPES_2D_NON_DIMENSION_COORDS = [
     "polar_stereographic",
 ]
 
-const COORDINATE_VARIABLES_KEYS = vcat(keys(COORD_ATTRS) |> collect, "typeOfLevel")
+const COORDINATE_VARIABLES_KEYS = vcat(keys(COORD_ATTRS) |> collect)
+
+# """
+#     GRIB_KEY_TO_DIMNAMES_MAP
+# Maps the GRIB keys to the name the variable will have in the GRIBDataset.
+# This follows (as much as possible) the names used when converting GRIB files
+# to netCDF with the `cdo` software (https://code.mpimet.mpg.de/projects/cdo/).
+# """
+# const GRIB_KEY_TO_DIMNAMES_MAP = Dict(
+#     "longitude"         => "lon",
+#     "latitude"          => "lat",
+#     "heightAboveGround" => "height",
+#     "hybrid"            => "lev",
+#     "isobaricInhPa"     => "plev",
+#     "isobaricInPa"      => "plev",
+#     "valid_time"        => "time"
+# )

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -66,7 +66,7 @@ julia> z[1:4, 3:6, 1, 1:2, 1]
 """
 struct GRIBDataset{T, N}
     index::FileIndex{T}
-    dims::NTuple{N, Dimension}
+    dims::NTuple{N, AbstractDim}
     attrib::Dict{String, Any}
 end
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,5 +1,3 @@
-abstract type AbstractDim end
-
 abstract type AbstractDimType end
 
 abstract type Horizontal <: AbstractDimType end
@@ -11,9 +9,40 @@ struct Lonlat <: Horizontal end
 struct NonDimensionCoords <: Horizontal end
 struct NoCoords <: Horizontal end
 
-struct Dimension{T<:AbstractDimType} <: AbstractDim
+abstract type AbstractDim{AbstractDimType} end
+
+"""
+    MessageDimension <: AbstractDim
+One dimension found in the data part of the GRIB message. Typically, this is `lon` and `lat`
+dimensions.
+"""
+struct MessageDimension{T} <: AbstractDim{T}
     name::String
     length::Int
+end
+
+"""
+    IndexedDimension <: AbstractDim
+Dimension created from reading the index values with the keys in the `COORDINATE_VARIABLES_KEYS` constant.
+"""
+struct IndexedDimension{T} <: AbstractDim{T}
+    name::String
+    values::Vector{Any}
+end
+
+"""
+    ArtificialDimension <: AbstractDim
+This type needs to be used when it is needed to create an artificial dimension.
+Typically this happens when some variables are defined on a similar type of level, but not on
+the same level values. For example, u10 and t2 are both defined on `heightAboveGround`, but
+the first is only defined at 10m and the second at 2m. In that case a `height` and a 
+`height_2` level will be created.
+"""
+struct ArtificialDimension{T} <: AbstractDim{T}
+    name::String
+    gribname::String
+    values::Vector{Any}
+    related_variables::Vector{<:String}
 end
 
 const Dimensions = Tuple{AbstractDim, Vararg{AbstractDim}}
@@ -21,6 +50,17 @@ const Dimensions = Tuple{AbstractDim, Vararg{AbstractDim}}
 Base.keys(dims::Dimensions) = [d.name for d in dims]
 Base.in(name::String, dims::Dimensions) = name in keys(dims)
 Base.getindex(dims::Dimensions, name::String) = first(dims[keys(dims) .== name])
+
+dimname(dim::AbstractDim) = dim.name
+
+dimlength(dim::AbstractDim) = dim.length
+dimlength(dim::Union{IndexedDimension, ArtificialDimension}) = length(dim.values)
+
+_dimtype(dim::AbstractDim{T}) where T = T
+_filter_on_dimtype(dims, type) = Tuple([dim for dim in dims if _dimtype(dim) == type])
+_get_verticaldims(dims) = _filter_on_dimtype(dims, Vertical)
+_get_horizontaldims(dims) = _filter_on_dimtype(dims, Horizontal)
+_get_otherdims(dims) = _filter_on_dimtype(dims, Other)
 
 function _horizontaltype(index::FileIndex)::Type{<:Horizontal}
     grid_type = getone(index, "gridType")
@@ -34,12 +74,12 @@ function _horizontaltype(index::FileIndex)::Type{<:Horizontal}
 end
 
 function _alldims(index::FileIndex)
-    dims = vcat(_horizdim(index, _horizontaltype(index)), _otherdims(index))
-    NTuple{length(dims), Dimension}(dims)
+    dims = vcat(_horizdim(index, _horizontaltype(index))..., _verticaldims(index)..., _otherdims(index)...)
+    NTuple{length(dims), AbstractDim}(dims)
 end
 
 function _otherdims(index::FileIndex; coord_keys = COORDINATE_VARIABLES_KEYS)
-    dims = Dimension[]
+    dims = AbstractDim[]
     for key in coord_keys
         # For the moment, we only consider `valid_time` key for time dimension.
         # This should be extended in the future
@@ -47,32 +87,56 @@ function _otherdims(index::FileIndex; coord_keys = COORDINATE_VARIABLES_KEYS)
             push!(dims, _build_otherdims(key, index))
         end
     end
-    dims
+    Tuple(dims)
 end
 
-function _build_otherdims(key, headers)
-    if key == "typeOfLevel"
-        Dimension{Vertical}("level", length(headers["level"]))
-    else
-        Dimension{Other}(key, length(headers[key]))
+_build_otherdims(key, headers) = IndexedDimension{Other}(key, headers[key])
+
+_verticaldims(index) = Tuple(_build_verticaldims(index))
+
+function _build_verticaldims(index)
+    dims = AbstractDim[]
+    type_of_levels = index["typeOfLevel"]
+
+    # We ignore those dimensions, since they imply a scalar coordinate variable
+    type_of_levels = filter(x -> x ∈ COORDINATE_VARIABLES_KEYS, type_of_levels)
+
+    # This checks if for some level types, some variables are defined on distinct level values.
+    # If so, it creates an artificial dimension for each of the distinct values.
+    for leveltype in type_of_levels
+        dimname = _map_dimname(leveltype)
+        filtered_index = filter_messages(index, typeOfLevel = leveltype)
+        distinct = _separate_distinct_levels(filtered_index)
+        if length(distinct) > 1
+            for (i, (dimvalues, varnames)) in enumerate(distinct)
+                distinct_dimname = _distinct_dimname(dimname, i)
+                dim = ArtificialDimension{Vertical}(distinct_dimname, dimname, dimvalues, varnames)
+                push!(dims, dim)
+
+            end
+        else
+            dim = IndexedDimension{Vertical}(dimname, filtered_index["level"])
+            push!(dims, dim)
+        end
     end
+    return dims
 end
 
 function _horizdim(index::FileIndex, ::Type{Lonlat})
-    Dimension{Horizontal}.(["longitude", "latitude"], [getone(index, "Nx"), getone(index, "Ny")])
+    Tuple(MessageDimension{Horizontal}.(["lon", "lat"], [getone(index, "Nx"), getone(index, "Ny")]))
 end
 
 function _horizdim(index::FileIndex, ::Type{NonDimensionCoords})
-    Dimension{Horizontal}.(["x", "y"], [getone(index, "Nx"), getone(index, "Ny")])
+    Tuple(MessageDimension{Horizontal}.(["x", "y"], [getone(index, "Nx"), getone(index, "Ny")]))
 end
 
 function _horizdim(index::FileIndex, ::Type{NoCoords})
-    Dimension{Other}("values", getone(index, "numberOfPoints")) 
+    Tuple(MessageDimension{Other}("values", getone(index, "numberOfPoints")))
 end
 
-_size_dims(dims) = Tuple([d.length for d in dims])
+_size_dims(dims) = Tuple([dimlength(d) for d in dims])
 
-function _dim_values(index::FileIndex, dim::Dimension{<:NonHorizontal})
+function _dim_values(index::FileIndex, dim::MessageDimension{<:NonHorizontal})
     vals = index[dim.name]
     # Convert time dimension to DateTime
     # if occursin("time", dim.name)
@@ -87,10 +151,10 @@ function _dim_values(index::FileIndex, dim::Dimension{<:NonHorizontal})
     identity.(vals)
 end
 
-function _dim_values(index::FileIndex, dim::Dimension{Horizontal})
-    if dim.name == "longitude"
+function _dim_values(index::FileIndex, dim::MessageDimension{Horizontal})
+    if dim.name == "lon"
         index._first_data[1][:, 1]
-    elseif dim.name == "latitude"
+    elseif dim.name == "lat"
         index._first_data[2][1, :]
     elseif dim.name == "x"
         index._first_data[1]
@@ -99,10 +163,75 @@ function _dim_values(index::FileIndex, dim::Dimension{Horizontal})
     end
 end
 
-Base.show(io::IO, mime::MIME"text/plain", dim::Dimension) = print(io, "$(dim.name) = $(dim.length)")
+_dim_values(index::FileIndex, dim::Union{<:ArtificialDimension, <:IndexedDimension}) = identity.(dim.values)
+
+# _map_dimname(dimname) = get(GRIB_KEY_TO_DIMNAMES_MAP, dimname, dimname)
+_map_dimname(dimname) = dimname
+
+function _separate_distinct_levels(levindex::FileIndex; tocheck = "level")
+    vals = get_values_from_filtered(levindex, "cfVarName", tocheck)
+    res = DefaultDict{Any, Vector{String}}(() -> Vector{String}())
+
+    for (k, v) in vals
+        push!(res[v], k)
+    end
+
+    return res
+end
+
+_distinct_dimname(dimname, i) = i == 1 ? dimname : "$(dimname)_$i"
+
+_is_in_artificial(varname, dim::AbstractDim) = false
+_is_in_artificial(varname, dim::ArtificialDimension) = varname in dim.related_variables
+
+function _replace_with_artificial(artificialdim, dims)
+    map(dims) do dim
+        if dimname(dim) == artificialdim.gribname
+            artificialdim
+        else
+            dim
+        end
+    end
+end
+
+message_indice(index::FileIndex, mind::MessageIndex, dim::AbstractDim) = nothing
+
+function message_indice(index::FileIndex, mind::MessageIndex, dim::IndexedDimension{<:Other})
+    vals = _dim_values(index, dim)
+    return findfirst(x -> x == mind[dimname(dim)], vals)
+end
+
+function message_indice(index::FileIndex, mind::MessageIndex, dim::AbstractDim{<:Vertical})
+    vals = _dim_values(index, dim)
+    !(dimname(dim) == mind["typeOfLevel"])  && (return nothing)
+    return findfirst(x -> x == mind["level"], vals)
+end
+
+function message_indice(index::FileIndex, mind::MessageIndex, dim::ArtificialDimension{<:Vertical})
+    vals = _dim_values(index, dim)
+    !(dim.gribname == mind["typeOfLevel"])  && (return nothing)
+    return findfirst(x -> x == mind["level"], vals)
+end
+
+function message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
+    indices = Int[]
+    for dim in dims
+        ind = message_indice(index, mind, dim)
+        !isnothing(ind) && (push!(indices, ind))
+    end
+    indices
+end
+
+"""
+    message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
+Find at which indices in `dims` correspond each GRIB message in `index`.
+"""
+messages_indices(index::FileIndex, dims::Dimensions) = [message_indices(index, mind, dims) for mind in index.messages]
+
+Base.show(io::IO, mime::MIME"text/plain", dim::MessageDimension) = print(io, "$(dim.name) = $(dimlength(dim))")
 function Base.show(io::IO, mime::MIME"text/plain", dims::Dimensions) 
     println(io, "Dimensions:")
     for dim in dims
-        println(io, "\t $(dim.name) = $(dim.length)")
+        println(io, "\t $(dim.name) = $(dimlength(dim))")
     end
 end

--- a/src/index.jl
+++ b/src/index.jl
@@ -168,3 +168,27 @@ end
 #         missing ∈ v && pop!(d, k)
 #     end
 # end
+
+"""
+    get_values_from_filtered(index, key, tocheck)
+For each `index` values in `key`, give the values in `tocheck` related with it.
+
+```jldoctest
+index = FileIndex(example_file)
+
+get_values_from_filtered(index, "cfVarName", "level")
+
+# output
+Dict{SubString{String}, Vector{Any}} with 2 entries:
+  "t" => [500, 850]
+  "z" => [500, 850]
+```
+"""
+function get_values_from_filtered(index, key, tocheck)
+    res = map(index[key]) do varname
+        kwargs = NamedTuple((Symbol(key) => varname,))
+        findex = filter_messages(index; kwargs...)
+        varname => findex[tocheck]
+    end
+    return Dict(res...)
+end

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -270,6 +270,7 @@ getoffset(mindex::MessageIndex) = mindex.offset
 getheaders(mindex::MessageIndex) = mindex.headers
 Base.length(mindex::MessageIndex) = mindex.length
 Base.getindex(mindex::MessageIndex, args...) = getindex(getheaders(mindex), args...)
+Base.haskey(mindex::MessageIndex, key) = haskey(getheaders(mindex), key)
 
 Base.show(io::IO, mime::MIME"text/plain", mind::MessageIndex) = show(io, mime, getheaders(mind))
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -37,8 +37,8 @@ Create a `DiskValues` object from matching the GRIB messages headers in `layer_i
 the dimensions values in `dims`.
 """
 function DiskValues(ds::GRIBDataset, layer_index::FileIndex{T}, dims::Dimensions) where T
-    otherdims = Tuple([dim for dim in dims if dim isa Dimension{<:NonHorizontal}])
-    horizdims = Tuple([dim for dim in dims if dim isa Dimension{<:Horizontal}])
+    messagedims = Tuple([dim for dim in dims if dim isa MessageDimension])
+    otherdims = Tuple([dim for dim in dims if !(dim isa MessageDimension)])
     N = length(dims)
     M = length(otherdims)
     offsets_array = Array{Int, M}(undef, _size_dims(otherdims))
@@ -47,7 +47,7 @@ function DiskValues(ds::GRIBDataset, layer_index::FileIndex{T}, dims::Dimensions
     for (mind, indices) in zip(layer_index.messages, all_indices)
         offsets_array[indices...] = getoffset(mind)
     end
-    DiskValues{T, N, M}(ds, layer_index, offsets_array, horizdims, otherdims)
+    DiskValues{T, N, M}(ds, layer_index, offsets_array, messagedims, otherdims)
 end
 
 Base.size(dv::DiskValues) = (_size_dims(dv.message_dims)..., _size_dims(dv.other_dims)...)
@@ -90,23 +90,23 @@ end
 DA.eachchunk(A::DiskValues) = DA.GridChunks(A, size(A))
 DA.haschunks(A::DiskValues) = DA.Unchunked()
 
-function message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
-    indices = Int[]
-    for dim in dims
-        if dim isa Dimension{<:NonHorizontal}
-            vals = _dim_values(index, dim)
-            ind = findfirst(x -> x == mind[dim.name], vals)
-            push!(indices, ind)
-        end
-    end
-    indices
-end
+# function message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
+#     indices = Int[]
+#     for dim in dims
+#         if dim isa MessageDimension{<:NonHorizontal}
+#             vals = _dim_values(index, dim)
+#             ind = findfirst(x -> x == mind[dim.name], vals)
+#             push!(indices, ind)
+#         end
+#     end
+#     indices
+# end
 
-"""
-    message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
-Find at which indices in `dims` correspond each GRIB message in `index`.
-"""
-messages_indices(index::FileIndex, dims::Dimensions) = [message_indices(index, mind, dims) for mind in index.messages]
+# """
+#     message_indices(index::FileIndex, mind::MessageIndex, dims::Dimensions)
+# Find at which indices in `dims` correspond each GRIB message in `index`.
+# """
+# messages_indices(index::FileIndex, dims::Dimensions) = [message_indices(index, mind, dims) for mind in index.messages]
 
 """
     Variable <: AbstractArray
@@ -115,7 +115,7 @@ Variable of a dataset `ds`. It can be a layer or a dimension. In case of a layer
 struct Variable{T, N, AT <: Union{Array{T, N}, DA.AbstractDiskArray{T, N}}} <: AbstractArray{T, N}
     ds::GRIBDataset
     name::String
-    dims::NTuple{N, Dimension}
+    dims::NTuple{N, AbstractDim}
     values::AT
     attrib::Dict{String, Any}
 end
@@ -124,12 +124,21 @@ Base.size(var::Variable) = _size_dims(var.dims)
 Base.getindex(var::Variable, I...) = getindex(parent(var), I...)
 
 function Variable(ds::GRIBDataset, key)
-    if key in ds.dims
-        dim = ds.dims[key]
+    dsdims = ds.dims
+    if key in dsdims
+        dim = dsdims[key]
         Variable(ds, dim)
     elseif key in getlayersname(ds)
         layer_index = filter_messages(ds.index, cfVarName = key)
         dims = _alldims(layer_index)
+
+        # A little bit tricky... If the variable is related to an artificial dimension,
+        # we identify the dimension and replace it in the reconstructed `dims`.
+        if any(_is_in_artificial.(key, dsdims))
+            artdim = filter(x -> _is_in_artificial(key, x), dsdims)
+            length(artdim) > 1 && error("More than one artificial for this variable. Not supported.")
+            dims = _replace_with_artificial(artdim[1], dims)
+        end
         dv = DiskValues(ds, layer_index, dims)
         attributes = layer_attributes(layer_index)
         Variable(ds, string(key), dims, dv, attributes)
@@ -138,7 +147,7 @@ function Variable(ds::GRIBDataset, key)
     end
 end
 
-function Variable(ds::GRIBDataset, dim::Dimension) 
+function Variable(ds::GRIBDataset, dim::AbstractDim) 
     vals = _dim_values(ds, dim)
     attributes = dim_attributes(dim)
     Variable(ds, dim.name, (dim,), vals, attributes)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -4,6 +4,7 @@ using Test
 using GRIBDatasets: getone
 using GRIBDatasets: DATA_ATTRIBUTES_KEYS, GRID_TYPE_MAP
 using GRIBDatasets: _to_datetime
+using GRIBDatasets: DiskValues, Variable
 
 
 @testset "dataset and variables" begin
@@ -14,7 +15,7 @@ using GRIBDatasets: _to_datetime
     varstring = "z"
     @testset "dataset indexing" begin
         vars = keys(ds)
-        @test vars[1] == "longitude"
+        @test vars[1] == "lon"
     
         @test GDS.getlayersname(ds)[1] == "z"
     
@@ -34,10 +35,23 @@ using GRIBDatasets: _to_datetime
         @test layer[1:10, 2:4, 1, 1, 1] isa AbstractArray{<:Any, 2}
 
         #indexing on the other dimensions
-        @test layer[1, 1, 1:3, 1:2, 1:2] isa AbstractArray{<:Any, 3}
+        @test layer[1, 1, 1:2, 1:3, 1:2] isa AbstractArray{<:Any, 3}
 
         #indexing on the all dimensions
-        @test layer[5:10, 2:4, 1:3, 1:2, 1:2] isa AbstractArray{<:Any, 5}
+        @test layer[5:10, 2:4, 1:2, 1:3, 1:2] isa AbstractArray{<:Any, 5}
+    end
+
+    @testset "variable indexing with redundant level" begin
+        ds2 = GRIBDataset(joinpath(dir_testfiles, "ENH18080914"))
+
+        u = ds2["u"]
+        @test u[:,:, 1, 1] isa AbstractArray{<:Any, 2}
+
+        @test_throws BoundsError u[:,:,1,2]
+
+        u10 = ds2["u10"]
+
+        t2 = ds2["t2m"]
     end
 
     @testset "upfront filtering" begin

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -1,8 +1,14 @@
 using GRIBDatasets
-using GRIBDatasets: _alldims, _horizontaltype, _horizdim, _dim_values, _size_dims, _otherdims
+using GRIBDatasets: _alldims, _horizontaltype, _horizdim, _dim_values, _size_dims, _otherdims, _verticaldims
+using GRIBDatasets: _separate_distinct_levels
 using GRIBDatasets: Horizontal, Vertical, Other, NonHorizontal
 using GRIBDatasets: Lonlat, NonDimensionCoords, NoCoords
-using GRIBDatasets: Dimension, Dimensions
+using GRIBDatasets: MessageDimension, IndexedDimension, ArtificialDimension, Dimensions, AbstractDim
+using GRIBDatasets: dimlength, dimname
+using GRIBDatasets: filter_messages, message_indices, message_indice, messages_indices
+using GRIBDatasets: _get_verticaldims, _get_horizontaldims, _get_otherdims
+using GRIBDatasets: _is_in_artificial
+using Test
 
 @testset "dimension from index" begin
     era5_path = joinpath(dir_testfiles, "era5-levels-members.grib")
@@ -19,14 +25,19 @@ using GRIBDatasets: Dimension, Dimensions
     @test _horizontaltype(lambert) == NonDimensionCoords
 
     erahoriz = _horizdim(era5, _horizontaltype(era5))
-    @test erahoriz[1] isa Dimension{Horizontal}
-    @test erahoriz[1].name == "longitude"
+    @test erahoriz[1] isa MessageDimension{Horizontal}
+    @test dimname(erahoriz[1]) == "lon"
 
     eraother = _otherdims(era5)
-    @test eraother[1] isa Dimension{<:Other}
+    @test eraother[1] isa IndexedDimension
     
+    eravertical = _verticaldims(era5)
+    @test eravertical[1].name == "isobaricInhPa"
+
     era_alldims = _alldims(era5)
     @test era_alldims isa Dimensions
+
+    @test dimname.(_get_verticaldims(era_alldims)) == dimname.(eravertical)
     # for lonlat grid, x dim must be one dimensional
     @test _dim_values(era5, era_alldims[1]) isa Vector
     lam_alldims = _alldims(lambert)
@@ -34,10 +45,33 @@ using GRIBDatasets: Dimension, Dimensions
     @test _dim_values(lambert, lam_alldims[1]) isa Matrix
 
     # first dimensions must be the horizontal ones
-    @test keys(era_alldims)[1:2] == ["longitude", "latitude"]
+    @test keys(era_alldims)[1:2] == ["lon", "lat"]
 
-    vertdim = era_alldims["level"]
-    @test length(_dim_values(era5, vertdim)) == vertdim.length
+    @test _size_dims(era_alldims) == (120, 61, 2, 10, 4)
 
-    @test _size_dims(era_alldims) == (120, 61, 10, 4, 2)
+    @testset "message indices" begin
+        dim = era_alldims[1]
+        mind = era5.messages[1]
+        vertdim = _get_verticaldims(era_alldims)[1]
+        @test message_indices(era5, mind, era_alldims) == [1, 1, 1]
+
+        indices = messages_indices(era5, era_alldims)
+        length(unique([e[2] for e in indices])) == 10
+    end
+
+    @testset "redundant vertical dims" begin
+        index = FileIndex(joinpath(dir_testfiles, "ENH18080914"))
+        filtered_index = filter_messages(index, typeOfLevel = "heightAboveGround")
+        distinct = _separate_distinct_levels(filtered_index; tocheck = "level")
+        @test length(distinct) == 2
+
+        vertdims = _verticaldims(index)
+
+        @test keys(vertdims) == ["hybrid", "heightAboveGround", "heightAboveGround_2"]
+
+        u10 = filter_messages(index, cfVarName = "u10")
+        indices = messages_indices(u10, _alldims(u10))
+
+        @test indices[1] == [1, 1]
+    end
 end

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,6 +1,7 @@
 using GRIBDatasets
 using GRIB
-using GRIBDatasets: FileIndex, filter_messages, with_messages, enforce_unique_attributes
+using GRIBDatasets: FileIndex, filter_messages, with_messages
+using GRIBDatasets: get_values_from_filtered
 
 
 @testset "index creation" begin
@@ -40,6 +41,12 @@ end
     @test length(filter_messages(mindexs, shortName = "z", number = 1)) == 8
 end
 
+@testset "utils" begin
+    grib_path = joinpath(dir_testfiles, "era5-levels-members.grib")
+    index = FileIndex(grib_path)
+    vals = get_values_from_filtered(index, "cfVarName", "level")
+    @test length(vals) == 2
+end
 # with_messages(index; paramId = 129, level = 500) do m
 #     println(m["level"])
 # end


### PR DESCRIPTION
This introduces quite a few changes in the dimension implementation.
It allows a GRIB dataset to have variables that are defined on multiple vertical levels.
For example, u10 and t2m are both defined on `heightAboveGround`, but only on 1 level each.
In that case two artificial dimensions will be created: `heightAboveGround` with single value 10 and `heightAboveGround_2` with single value 2.
This is the same approach as converting GRIB files to netCDF with the cdo software 