### PR TITLE
Better handling of irregular grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliageo.org/GRIBDatasets.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliageo.org/GRIBDatasets.jl/dev/)
-[![Build Status](https://github.com/tcarion/GRIBDatasets.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/GRIBDatasets.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/JuliaGeo/GRIBDatasets.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/GRIBDatasets.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/JuliaGeo/GRIBDatasets.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaGeo/GRIBDatasets.jl)
 
 ## Description

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Internals" => Any[
-            "internals.md",
+            # "internals.md",
             "FileIndex" => "file_index.md"
         ],
     ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Internals" => Any[
-            # "internals.md",
+            "internals.md",
             "FileIndex" => "file_index.md"
         ],
     ],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,9 +5,3 @@ CurrentModule = GRIBDatasets
 # GRIBDatasets
 
 Documentation for [GRIBDatasets](https://github.com/tcarion/GRIBDatasets.jl).
-
-```@docs
-GRIBDataset
-FileIndex
-MessageIndex
-```

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -85,7 +85,12 @@ Base.getindex(ds::Dataset, key) = cfvariable(ds, string(key))
 getlayersid(ds::GRIBDataset) = ds.index["paramId"]
 getlayersname(ds::GRIBDataset) = string.(ds.index["cfVarName"])
 
-getvars(ds::GRIBDataset) = vcat(keys(ds.dims), getlayersname(ds))
+function getvars(ds::GRIBDataset) 
+    dimension_vars = keys(filter(x -> !_is_coordinates(ds.index, x), ds.dims))
+    layers_vars = getlayersname(ds)
+
+    vcat(dimension_vars, layers_vars)
+end
 
 _dim_values(ds::GRIBDataset, dim) = _dim_values(ds.index, dim)
 _get_dim(ds::GRIBDataset, key) = _get_dim(ds.dims, key)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -86,10 +86,10 @@ getlayersid(ds::GRIBDataset) = ds.index["paramId"]
 getlayersname(ds::GRIBDataset) = string.(ds.index["cfVarName"])
 
 function getvars(ds::GRIBDataset) 
-    dimension_vars = keys(filter(x -> !_is_coordinates(ds.index, x), ds.dims))
+    dimension_vars = keys(filter(x -> _has_coordinates(ds.index, x), ds.dims))
     layers_vars = getlayersname(ds)
-
-    vcat(dimension_vars, layers_vars)
+    coordinates_vars = additional_coordinates_varnames(ds.dims)
+    vcat(dimension_vars, coordinates_vars, layers_vars)
 end
 
 _dim_values(ds::GRIBDataset, dim) = _dim_values(ds.index, dim)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -7,62 +7,6 @@ It can be created with the path to the GRIB file:
 ```julia
 ds = GRIBDataset(example_file);
 ```
-
-The list of variables can be accessed:
-
-```julia-repl
-julia> keys(ds)
-7-element Vector{String}:
- "longitude"
- "latitude"
- "number"
- "valid_time"
- "level"
- "z"
- "t"
-```
-
-We can then index any of the variables or dimensions:
-```julia-repl
-julia> z = ds["z"]
-Variable `z` with dims:
-Dimensions:
-         longitude = 120
-         latitude = 61
-         number = 10
-         valid_time = 4
-         level = 2
-
-julia> ds["number"] |> collect
-10-element Vector{Int64}:
- 0
- 1
- 2
- 3
- 4
- 5
- 6
- 7
- 8
- 9
-```
-
-We can slice the variables along the dimensions:
-```julia-repl
-julia> z[1:4, 3:6, 1, 1:2, 1]
-4×4×2 reshape(::Array{Union{Missing, Float64}, 5}, 4, 4, 2) with eltype Union{Missing, Float64}:
-[:, :, 1] =
- 51038.7  50873.7  50731.2  50824.5
- 51058.0  50859.0  50656.2  50682.0
- 51077.5  50838.5  50578.5  50541.2
- 51095.0  50807.2  50490.5  50398.5
-
-[:, :, 2] =
- 51031.0  50822.3  50672.5  50773.0
- 51067.5  50820.5  50582.8  50647.5
- 51102.0  50816.0  50471.3  50526.0
- 51133.3  50806.3  50351.3  50399.3
-```
 """
 struct GRIBDataset{T, N} <: AbstractDataset
     index::FileIndex{T}

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -5,8 +5,24 @@ abstract type Vertical <: AbstractDimType end
 abstract type Other <: AbstractDimType end
 const NonHorizontal = Union{Vertical, Other}
 
-struct RegularGrid <: Horizontal end 
+"""
+    RegularGrid <: Horizontal
+Represent regular grid types (typically regular_ll and regular_gg).
+The typical messages data is a 2-D matrix.
+"""
+struct RegularGrid <: Horizontal end
+
+"""
+    NonRegularGrid <: Horizontal
+Represent non-regular grid types.
+The typical messages data is a 2-D matrix.
+"""
 struct NonRegularGrid <: Horizontal end
+
+"""
+    OtherGrid <: Horizontal
+Represent non-regular grid types, where the typical messages data is a 1-D vector.
+"""
 struct OtherGrid <: Horizontal end
 
 abstract type AbstractDim{AbstractDimType} end

--- a/src/index.jl
+++ b/src/index.jl
@@ -24,37 +24,6 @@ getheaders(index::FileIndex) = index.unique_headers
 Construct a [`FileIndex`](@ref) for the file `grib_path`, storing only the keys in `index_keys`.
 It is possible to read only specific values by specifying them in `filter_by_values`.
 The values of the headers can be accessed with `getindex`.
-
-# Example
-
-```jldoctest
-index = FileIndex(example_file)
-
-# output
-FileIndex{Float64} with 160 messages
-Headers summary:
-Dict{AbstractString, Vector{Any}} with 39 entries:
-  "edition"                          => [1]
-  "jDirectionIncrementInDegrees"     => [3.0]
-  "number"                           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  "time"                             => [1483228800, 1483272000, 1483315200, 14…
-  "dataType"                         => ["an"]
-  "stepUnits"                        => [1]
-  "subCentre"                        => [0]
-  "jPointsAreConsecutive"            => [0]
-  "level"                            => [500, 850]
-  "name"                             => ["Geopotential", "Temperature"]
-  "step"                             => [0]
-  "jScansPositively"                 => [0]
-  "latitudeOfLastGridPointInDegrees" => [-90.0]
-  "valid_time"                       => [1483228800, 1483272000, 1483315200, 14…
-  "dataDate"                         => [20170101, 20170102]
-  "iScansNegatively"                 => [0]
-  "numberOfPoints"                   => [7320]
-  "missingValue"                     => [9999]
-  "gridType"                         => ["regular_ll"]
-  ⋮                                  => ⋮
-```
 """
 function FileIndex(grib_path::String; index_keys = ALL_KEYS, filter_by_values = Dict())
     messages = MessageIndex[]

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -288,6 +288,8 @@ function filter_messages(mindexs::Vector{<:MessageIndex}; query...)
     ms
 end
 
-function get_offsets(mindexs::Vector{<:MessageIndex}, key, val)
+function filter_offsets(mindexs::Vector{<:MessageIndex}, key, val)
     getoffset.(filter(x -> getheaders(x)[key] == val, mindexs))
 end
+
+get_offsets(mindexs::Vector{<:MessageIndex}) = getoffset.(mindexs)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -58,7 +58,6 @@ Base.size(dv::DiskValues) = (_size_dims(dv.message_dims)..., _size_dims(dv.other
 # we have to threat them separately from the other dimensions (typically time, number, vertical...). This is
 # what makes this code quite complicated. There's probably a clever/prettier way of doing this, but this one works for now...
 function DA.readblock!(A::DiskValues, aout, i::AbstractUnitRange...)
-    @show i
     general_index = A.ds.index
     grib_path = general_index.grib_path
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -134,6 +134,17 @@ function Variable(ds::GRIBDataset, key)
         Variable(ds, dim)
     elseif key in getlayersname(ds)
         layer_index = filter_messages(ds.index, cfVarName = key)
+        
+        levels = [mind["typeOfLevel"] for mind in layer_index.messages]
+
+        if length(unique(levels)) !== 1
+            error("""
+            The variable `$key` is defined on multiple types of vertical levels. This is not supported by GRIBDatasets.
+            To overcome this issue, you can try to filter the GRIB file on some specific level. Example:
+            ds = GRIBDataset("$(path(ds))", filter_by_values=Dict("typeOfLevel" => "$(levels[1])"))
+            """)
+        end
+
         dims = _alldims(layer_index)
 
         # A little bit tricky... If the variable is related to an artificial dimension,
@@ -160,7 +171,7 @@ function Variable(ds::GRIBDataset, key)
 
         Variable(ds, key, _filter_horizontal_dims(ds.dims), values, coordinate_attributes(key))
     else
-        error("key $key not found in dataset")
+        error("The key `$key` was been found in the dataset. Available keys: $(keys(ds))")
     end
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -136,12 +136,13 @@ function Variable(ds::GRIBDataset, key)
         layer_index = filter_messages(ds.index, cfVarName = key)
         
         levels = [mind["typeOfLevel"] for mind in layer_index.messages]
-
-        if length(unique(levels)) !== 1
+        unique_levels = unique(levels)
+        if length(unique_levels) !== 1
+            examples = ["GRIBDataset(\"$(path(ds))\", filter_by_values=Dict(\"typeOfLevel\" => \"$(level)\"))\n" for level in unique_levels]
             error("""
             The variable `$key` is defined on multiple types of vertical levels. This is not supported by GRIBDatasets.
-            To overcome this issue, you can try to filter the GRIB file on some specific level. Example:
-            ds = GRIBDataset("$(path(ds))", filter_by_values=Dict("typeOfLevel" => "$(levels[1])"))
+            To overcome this issue, you can try to filter the GRIB file on some specific level. In your case, try to re-open the dataset with one of:
+            $(join(examples))
             """)
         end
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -134,6 +134,33 @@ using GRIBDatasets: CDM
     @testset "time dimension" begin
         @test ds["valid_time"][1] isa DateTime
     end
+
+    @testset "reduced gaussian grid" begin
+        reduced_gg_path = joinpath(dir_testfiles, "reduced_gg.grib")
+
+        dsrgg = GRIBDataset(reduced_gg_path)
+
+        @test haskey(dsrgg, "longitude")
+        @test haskey(dsrgg, "latitude")
+
+        @test dsrgg["latitude"] isa AbstractVector
+        @test size(dsrgg["longitude"]) == (GDS.dimlength(dsrgg.dims[1]), )
+        @test dsrgg["longitude"][1:3] == [0.,18.,36.]
+        @test dsrgg["latitude"][:] == dsrgg.index._first_data[2][:]
+    end
+
+    @testset "lamber grid" begin
+        lambert_path = joinpath(dir_testfiles, "lambert_grid.grib")
+        lambert = GRIBDataset(lambert_path)
+
+        @test haskey(lambert, "longitude")
+        @test haskey(lambert, "latitude")
+
+        @test lambert["latitude"] isa AbstractMatrix
+        @test lambert["longitude"] isa AbstractMatrix
+
+        @test lambert["latitude"][:] == lambert.index._first_data[2][:]
+    end
 end
 
 @testset "test all files" begin

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -161,6 +161,16 @@ using GRIBDatasets: CDM
 
         @test lambert["latitude"][:] == lambert.index._first_data[2][:]
     end
+
+    @testset "filter dataset by values" begin
+        fds = GRIBDataset(grib_path; filter_by_values = Dict("cfVarName" => "t"))
+
+        @test !haskey(fds, "z")
+
+        @test all(fds["t"].var.values.offsets .== ds["t"].var.values.offsets)
+        @test all(ds["t"][:,:,2, 3, 2] .== fds["t"][:,:,2, 3, 2])
+        @test all(ds["t"][:,:,2, 3:4, 2] .== fds["t"][:,:,2, 3:4, 2])
+    end
 end
 
 @testset "test all files" begin

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -1,8 +1,8 @@
 using GRIBDatasets
-using GRIBDatasets: _alldims, _horizontaltype, _horizdim, _dim_values, _size_dims, _otherdims, _verticaldims
+using GRIBDatasets: _alldims, _horizontal_gridtype, _horizdims, _dim_values, _size_dims, _otherdims, _verticaldims
 using GRIBDatasets: _separate_distinct_levels, _get_dim
 using GRIBDatasets: Horizontal, Vertical, Other, NonHorizontal
-using GRIBDatasets: Lonlat, NonDimensionCoords, NoCoords
+using GRIBDatasets: RegularGrid, NonRegularGrid, OtherGrid
 using GRIBDatasets: MessageDimension, IndexedDimension, ArtificialDimension, Dimensions, AbstractDim
 using GRIBDatasets: dimlength, dimname
 using GRIBDatasets: filter_messages, message_indices, message_indice, messages_indices
@@ -20,12 +20,12 @@ using Test
     lambert_path = joinpath(dir_testfiles, "lambert_grid.grib")
     lambert = FileIndex(lambert_path)
 
-    @test _horizontaltype(era5) == Lonlat
-    @test _horizontaltype(gaussian) == Lonlat
-    @test _horizontaltype(lambert) == NonDimensionCoords
+    @test _horizontal_gridtype(era5) == RegularGrid
+    @test _horizontal_gridtype(gaussian) == RegularGrid
+    @test _horizontal_gridtype(lambert) == NonRegularGrid
 
-    erahoriz = _horizdim(era5, _horizontaltype(era5))
-    @test erahoriz[1] isa MessageDimension{Horizontal}
+    erahoriz = _horizdims(era5, _horizontal_gridtype(era5))
+    @test erahoriz[1] isa MessageDimension{<:Horizontal}
     @test dimname(erahoriz[1]) == "lon"
 
     eraother = _otherdims(era5)

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -6,7 +6,7 @@ using GRIBDatasets: RegularGrid, NonRegularGrid, OtherGrid
 using GRIBDatasets: MessageDimension, IndexedDimension, ArtificialDimension, Dimensions, AbstractDim
 using GRIBDatasets: dimlength, dimname
 using GRIBDatasets: filter_messages, message_indices, message_indice, messages_indices
-using GRIBDatasets: _get_verticaldims, _get_horizontaldims, _get_otherdims
+using GRIBDatasets: _get_verticaldims, _get_horizontaldims, _get_otherdims, additional_coordinates_varnames
 using GRIBDatasets: _is_in_artificial, _replace_with_artificial, _is_length_consistent
 using Test
 
@@ -14,15 +14,19 @@ using Test
     era5_path = joinpath(dir_testfiles, "era5-levels-members.grib")
     era5 = FileIndex(era5_path)
 
-    gaussian_path = joinpath(dir_testfiles, "regular_gg_pl.grib")
-    gaussian = FileIndex(gaussian_path)
+    regular_gg_path = joinpath(dir_testfiles, "regular_gg_pl.grib")
+    regular_gg = FileIndex(regular_gg_path)
 
     lambert_path = joinpath(dir_testfiles, "lambert_grid.grib")
     lambert = FileIndex(lambert_path)
 
+    reduced_gg_path = joinpath(dir_testfiles, "reduced_gg.grib")
+    reduced_gg = FileIndex(reduced_gg_path)
+
     @test _horizontal_gridtype(era5) == RegularGrid
-    @test _horizontal_gridtype(gaussian) == RegularGrid
+    @test _horizontal_gridtype(regular_gg) == RegularGrid
     @test _horizontal_gridtype(lambert) == NonRegularGrid
+    @test _horizontal_gridtype(reduced_gg) == OtherGrid
 
     erahoriz = _horizdims(era5, _horizontal_gridtype(era5))
     @test erahoriz[1] isa MessageDimension{<:Horizontal}
@@ -43,7 +47,12 @@ using Test
     @test _dim_values(era5, era_alldims[1]) isa Vector
     lam_alldims = _alldims(lambert)
     # for lambert grid, x dim must be 2D
-    @test _dim_values(lambert, lam_alldims[1]) isa Matrix
+    @test isnothing(_dim_values(lambert, lam_alldims[1]))
+    
+    @test isnothing(_dim_values(reduced_gg, _alldims(reduced_gg)[1]))
+
+    @test additional_coordinates_varnames(lam_alldims) == ["longitude", "latitude"]
+    @test additional_coordinates_varnames(era_alldims) == []
 
     # first dimensions must be the horizontal ones
     @test keys(era_alldims)[1:2] == ["lon", "lat"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using GRIBDatasets
 using Test
 
-GDS = GRIBDatasets
+const GDS = GRIBDatasets
 
 const dir_tests = abspath(joinpath(dirname(pathof(GRIBDatasets)), "..", "test"))
 const dir_testfiles = abspath(joinpath(dir_tests, "sample-data"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ test_files = joinpath.(dir_testfiles, [
     "regular_ll_wrong_increment.grib", # OK
     "scanning_mode_64.grib", # OK
     "t_analysis_and_fc_0.grib", # OK
+    "reduced_gg.grib", # OK
 ])
 
 @testset "GRIBDatasets.jl" begin


### PR DESCRIPTION
This should improve the handling of irregular grids, like Lambert or reduced Gaussian grids.
For these grids, the created dataset has "longitude" and "latitude" variables. The behaviour for such cases was inspired from the python [cfgrib](https://github.com/ecmwf/cfgrib) package.

It should solve issues #17 and #13 