### PR TITLE
small change for upcoming CommonDataModel 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GRIBDatasets"
 uuid = "82be9cdb-ee19-4151-bdb3-b400788d9abc"
 authors = ["tcarion <tristan.carion@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CommonDataModel = "1fbeeb36-5f17-413c-809b-666fb144f157"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -24,7 +24,7 @@ GRIBDataset(filepath::AbstractString; filter_by_values = Dict()) = GRIBDataset(F
 
 Base.keys(ds::Dataset) = getvars(ds)
 Base.haskey(ds::Dataset, key) = key in keys(ds)
-Base.getindex(ds::Dataset, key) = cfvariable(ds, string(key))
+Base.getindex(ds::Dataset, key::Union{Symbol,AbstractString}) = cfvariable(ds, string(key))
 
 getlayersid(ds::GRIBDataset) = ds.index["paramId"]
 getlayersname(ds::GRIBDataset) = string.(ds.index["cfVarName"])


### PR DESCRIPTION
This PR avoids some ambiguity issues for the upcoming CommonDataModel 0.3.

(In the new version of CommonDataModel 0.3, one can access variables also by standard name, e.g.
`ds[CF"longitude"]` will be a variable whose standard name is "longitude". CF"longitude" will have the type CommonDataModel.CFStdName and we need to dispatch on that)

