### PR TITLE
allow to use a different masking value than missing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 GRIB = "b16dfd50-4035-11e9-28d4-9dfe17e6779b"
 
 [compat]
-CommonDataModel = "^0.2.1, 0.3"
+CommonDataModel = "0.3.4"
 DataStructures = "0.18"
 DiskArrays = "0.3"
 GRIB = "0.3, 0.4"

--- a/src/GRIBDatasets.jl
+++ b/src/GRIBDatasets.jl
@@ -5,7 +5,8 @@ using GRIB
 using DataStructures
 import DiskArrays as DA
 using CommonDataModel: AbstractDataset, AbstractVariable, show_dim, CFVariable
-import CommonDataModel: path, name, dimnames, isopen, attribnames, attrib, dataset
+import CommonDataModel: path, name, dimnames, isopen, attribnames, attrib,
+    dataset, maskingvalue
 import CommonDataModel as CDM
 
 const DEFAULT_EPOCH = DateTime(1970, 1, 1, 0, 0)

--- a/src/cfvariables.jl
+++ b/src/cfvariables.jl
@@ -1,6 +1,6 @@
 
 _get_dim(cfvar::CFVariable, dimname) = _get_dim(cfvar.var, dimname)
-function cfvariable(ds, varname)
+function cfvariable(ds, varname; maskingvalue = maskingvalue(ds))
     v = Variable(ds, string(varname))
     misval = missing_value(v)
     CDM.cfvariable(
@@ -8,6 +8,7 @@ function cfvariable(ds, varname)
         _v = v,
         missing_value = isnothing(misval) ? eltype(v)[] : [misval],
         attrib = cflayer_attributes(v),
+        maskingvalue = maskingvalue,
     )
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -8,19 +8,21 @@ It can be created with the path to the GRIB file:
 ds = GRIBDataset(example_file);
 ```
 """
-struct GRIBDataset{T, N} <: AbstractDataset
+struct GRIBDataset{T, N, Tmaskingvalue} <: AbstractDataset
     index::FileIndex{T}
     dims::NTuple{N, AbstractDim}
     attrib::Dict{String, Any}
+    maskingvalue::Tmaskingvalue
 end
 
 const Dataset = GRIBDataset
 
-function GRIBDataset(index::FileIndex)
-    GRIBDataset(index, _alldims(index), dataset_attributes(index)) 
+function GRIBDataset(index::FileIndex; maskingvalue = missing)
+    GRIBDataset(index, _alldims(index), dataset_attributes(index), maskingvalue)
 end
 
-GRIBDataset(filepath::AbstractString; filter_by_values = Dict()) = GRIBDataset(FileIndex(filepath; filter_by_values))
+GRIBDataset(filepath::AbstractString; filter_by_values = Dict(), kwargs...) =
+    GRIBDataset(FileIndex(filepath; filter_by_values); kwargs...)
 
 Base.keys(ds::Dataset) = getvars(ds)
 Base.haskey(ds::Dataset, key) = key in keys(ds)
@@ -46,6 +48,7 @@ dimnames(ds::GRIBDataset) = keys(ds.dims)
 
 attribnames(ds::GRIBDataset) = keys(ds.attrib)
 attrib(ds::GRIBDataset, attribname::String) = ds.attrib[attribname]
+maskingvalue(ds::GRIBDataset) = ds.maskingvalue
 
 # _dim_values(ds::GRIBDataset, dim::Dimension{Horizontal}) = _dim_values(ds.index, dim)
 


### PR DESCRIPTION
Currently missing values (and fill values) are loaded as `missing` in Julia.  For some use cases, it is preferable to use different special values like `NaN`s (e.g. for GPUs, or interfacing with other C libraries). 

This PR allows the user to e.g. use `NaN` either per variable or per datasets.

What do you think?