### PR TITLE
Update conversion from GRIB to NetCDF example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ using Downloads: download
 
 grib_file = download("https://github.com/JuliaGeo/GRIBDatasets.jl/raw/98356af026ea39a5ec0b5e64e4289105492321f8/test/sample-data/era5-levels-members.grib")
 netcdf_file = "test.nc"
-NCDatasets.write(netcdf_file,GRIBDataset(grib_file))
+NCDataset(netcdf_file,"c") do ds
+    write(ds,GRIBDataset(grib_file))
+end
 ```
 ## Opening issues:
 GRIB format files may have a (very) large amount of different shapes. `GRIBDatasets` might not work for your specific edge case. If this happens, please open an issue, if possible providing the file triggering the bug.


### PR DESCRIPTION
The call  `NCDatasets.write(netcdf_file,GRIBDataset(grib_file))` does not dispatch on any type defined in NCDatasets and the function `write` is a generic function from julia Base. Currently, NCDatasets is the only module which defines a function `write(dest_filename::AbstractString, src::CommonDataModel.AbstractDataset)`. I am wondering if it is not better to change this example with the netcdf dataset as the first argument to `write`.

For your information, I am working on [ZarrDatasets.jl](https://github.com/JuliaGeo/ZarrDatasets.jl) (still unregistered) and the GRIB to Zarr conversion also works in a very similar way:

```julia
using GRIBDatasets
using Downloads: download
using ZarrDatasets

grib_file = download("https://github.com/JuliaGeo/GRIBDatasets.jl/raw/98356af026ea39a5ec0b5e64e4289105492321f8/test/sample-data/era5-levels-members.grib")

zarr_dir = tempname()
mkdir(zarr_dir)
ZarrDataset(zarr_dir,"c") do ds
    write(ds,GRIBDataset(grib_file))
end
```