### PR TITLE
export dimnames

### DIFF
--- a/src/GRIBDatasets.jl
+++ b/src/GRIBDatasets.jl
@@ -20,6 +20,6 @@ include("dataset.jl")
 include("variables.jl")
 include("cfvariables.jl")
 
-export GRIBDataset, FileIndex
+export GRIBDataset, FileIndex, dimnames
 
 end


### PR DESCRIPTION
A GRIB file may contains many Dimensions like this:
```
Dataset: 20240411000000-0h-oper-fc.grib2
Group: /

Dimensions
   lon = 1440
   lat = 721
   heightAboveGround = 1
   heightAboveGround_2 = 1
   heightAboveGround_3 = 1
   isobaricInhPa = 13
   isobaricInhPa_2 = 13
   isobaricInhPa_3 = 13
   isobaricInhPa_4 = 13
   isobaricInhPa_5 = 13
   isobaricInhPa_6 = 13
   isobaricInhPa_7 = 13
   isobaricInhPa_8 = 13
   depthBelowLandLayer = 1
   depthBelowLandLayer_2 = 1
   depthBelowLandLayer_3 = 1
   depthBelowLandLayer_4 = 1
   valid_time = 1
```
We need to know which Dimension a Variable contains before accessing that Variable. Currently I can get this Dimension info with `GRIBDatasets.CDM.dimnames(ds["d"])`  which is long.