### PR TITLE
Forward DiskArrays.jl methods to Variable

### DIFF
--- a/src/messages.jl
+++ b/src/messages.jl
@@ -259,7 +259,7 @@ mind["name"]
 """
 function MessageIndex(message::GRIB.Message; index_keys = ALL_KEYS)
     values = read_message.(Ref(message), index_keys)
-    headers = Dict(k => v for (k,v) in zip(index_keys, values))
+    headers = Dict{String,Any}(k => v for (k, v) in zip(index_keys, values))
     
     offset = Int(message["offset"])
     length = message["totalLength"]
@@ -280,12 +280,11 @@ function filter_messages(mindexs::Vector{<:MessageIndex}, k::AbstractString, v)
 end
 
 
-function filter_messages(mindexs::Vector{<:MessageIndex}; query...)
-    ms = deepcopy(mindexs)
+function filter_messages(ms::Vector{<:MessageIndex}; query...)
     for (k, v) in query
         ms = filter_messages(ms, string(k), v)
     end
-    ms
+    return ms
 end
 
 function filter_offsets(mindexs::Vector{<:MessageIndex}, key, val)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -107,7 +107,7 @@ Base.parent(var::Variable) = var.values
 Base.size(var::Variable) = _size_dims(var.dims)  
 Base.getindex(var::Variable, I...) = getindex(parent(var), I...)
 
-DA.eachchunk(A::Variable) = DA.eachchunks(parent(A))
+DA.eachchunk(A::Variable) = DA.eachchunk(parent(A))
 DA.haschunks(A::Variable) = DA.haschunks(parent(A))
 DA.readblock!(A::Variable, aout, i::AbstractUnitRange...) =
     DA.readblock!(parent(A), aout, i...)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -107,6 +107,11 @@ Base.parent(var::Variable) = var.values
 Base.size(var::Variable) = _size_dims(var.dims)  
 Base.getindex(var::Variable, I...) = getindex(parent(var), I...)
 
+DA.eachchunk(A::Variable) = DA.eachchunks(parent(A))
+DA.haschunks(A::Variable) = DA.haschunks(parent(A))
+DA.readblock!(A::Variable, aout, i::AbstractUnitRange...) =
+    DA.readblock!(parent(A), aout, i...)
+
 ndims(::AbstractGRIBVariable{T,N}) where {T,N} = N
 varname(var::Variable) = var.name
 dims(var::Variable) = var.dims

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 GRIB = "b16dfd50-4035-11e9-28d4-9dfe17e6779b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -1,5 +1,6 @@
 using GRIBDatasets
 using Dates
+using DiskArrays
 using Test
 using GRIBDatasets: getone
 using GRIBDatasets: Variable
@@ -28,6 +29,16 @@ using GRIBDatasets: CDM
         @test CDM.dataset(var) == ds
 
         @test CDM.name(ds[:t]) == CDM.name(ds["t"])
+    end
+
+    @testset "DiskArrays on Variable" begin
+        var = ds[:z].var
+        size(var)
+        @test DiskArrays.eachchunk(var) == DiskArrays.eachchunk(parent(var))
+        @test DiskArrays.haschunks(var) == DiskArrays.haschunks(parent(var))
+        block = zeros(10, 10, 1, 1, 1)
+        DiskArrays.readblock!(var, block, 1:10, 1:10, 1:1, 1:1, 1:1) 
+        @test all(block .== var[1:10, 1:10, 1, 1, 1])
     end
 
     @testset "dataset indexing" begin


### PR DESCRIPTION
This PR forwards DiskArrays methods to the parent object.

The reason is its nice to just call `readblock!` in a wrapper array to avoid some compilation time, but currently this will fail on `Variable`.