### PR TITLE
pin eccodes_jll=2.28 to make variable names stable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ eccodes_jll = "b04048ba-5ccd-5610-b3f6-85129a548705"
 CommonDataModel = "0.3.4"
 DataStructures = "0.18"
 DiskArrays = "0.3, 0.4"
-eccodes_jll = "2.28"
+eccodes_jll = "~2.28"
 GRIB = "0.3, 0.4"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GRIBDatasets"
 uuid = "82be9cdb-ee19-4151-bdb3-b400788d9abc"
 authors = ["tcarion <tristan.carion@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CommonDataModel = "1fbeeb36-5f17-413c-809b-666fb144f157"
@@ -9,11 +9,13 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 GRIB = "b16dfd50-4035-11e9-28d4-9dfe17e6779b"
+eccodes_jll = "b04048ba-5ccd-5610-b3f6-85129a548705"
 
 [compat]
 CommonDataModel = "0.3.4"
 DataStructures = "0.18"
 DiskArrays = "0.3, 0.4"
+eccodes_jll = "2.28"
 GRIB = "0.3, 0.4"
 julia = "1"
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -122,9 +122,9 @@ using GRIBDatasets: CDM
         u = ds2["u"]
         @test u[:,:, 1, 1] isa AbstractArray{<:Any, 2}
         @test_throws BoundsError u[:,:,1,2]
-        u10 = ds2["avg_10u"]
+        u10 = ds2["u10"]
         @test GDS._dim_values(GDS._get_dim(u10, "heightAboveGround_2")) == [10]
-        t2m = ds2["mean2t"]
+        t2m = ds2["t2m"]
         @test GDS._dim_values(GDS._get_dim(t2m, "heightAboveGround")) == [2]
     end
 

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -79,7 +79,7 @@ using Test
 
         @test keys(vertdims) == ["hybrid", "heightAboveGround", "heightAboveGround_2"]
 
-        u10 = filter_messages(index, cfVarName = "avg_10u")
+        u10 = filter_messages(index, cfVarName = "u10")
         indices = messages_indices(u10, _alldims(u10))
 
         @test indices[1] == [1, 1]


### PR DESCRIPTION
This is related to https://github.com/JuliaGeo/GRIBDatasets.jl/issues/35

I think the best approach is to pin eccodes_jll to 2.28 and release GRIBDatasets 0.3.3. This would mean that user code should continue to work of anyone that have set compat GRIBDatasets=0.3 when they update their project.

After this is done, we can make a PR that pin eccodes_jll to 2.36 and release GRIBDatasets as 0.4. The variables names should be part of GRIBDatasets public interface and I therefore believe that bumping eccodes_jll versions should result in a breaking release.

In the future, we could make a breaking release to update eccodes_jll once a year or when we are doing a breaking release anyway. 

Alternatively, eccodes_jll should be pinned in GRIB.jl if short names are considered a stable part of the interface there.

@Alexander-Barth @tcarion 
