### PR TITLE
Check if parent variable is an array in readblock!

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -133,7 +133,11 @@ Base.getindex(var::Variable{T,N,Array{T,N}}, I...) where {T,N} =
     getindex(parent(var), I...)
 
 function DA.readblock!(A::Variable, aout, i::AbstractUnitRange...)
-    DA.readblock!(parent(A), aout, i...)
+    if parent(A) isa Array # in this case it's not really a diskarray
+        aout .= parent(A)[i...]
+    else 
+        DA.readblock!(parent(A), aout, i...)
+    end
 end
 DA.eachchunk(A::Variable) = DA.eachchunk(parent(A))
 DA.haschunks(A::Variable) = DA.haschunks(parent(A))


### PR DESCRIPTION
Implement a check to determine if the parent variable is an array in readblock!

`readblock!` normally isn't called for variables with array parent, but in https://github.com/rafaqz/Rasters.jl/pull/966 we found a case where it is and this immediately errors.

This is a bit of a temporary fix to avoid that error. In the long term 1) CDM changes will affect this a little bit, 2) maybe we want to change `DA.@implement_diskarray Variable` to `DA.@implement_diskarray Variable{<:Any,<:Any,DiskValues}?, 3) maybe we could avoid eagerly reading some values.

