### PR TITLE
Prepare common data model 0.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
-          - 'nightly'
+          - '1'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GRIBDatasets"
 uuid = "82be9cdb-ee19-4151-bdb3-b400788d9abc"
 authors = ["tcarion <tristan.carion@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 CommonDataModel = "1fbeeb36-5f17-413c-809b-666fb144f157"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ GRIB = "b16dfd50-4035-11e9-28d4-9dfe17e6779b"
 eccodes_jll = "b04048ba-5ccd-5610-b3f6-85129a548705"
 
 [compat]
-CommonDataModel = "0.3.4"
+CommonDataModel = "0.4"
 DataStructures = "0.18"
 DiskArrays = "0.3, 0.4"
 eccodes_jll = "~2.36"

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -125,7 +125,6 @@ dataset(var::AbstractGRIBVariable) = var.ds
 
 _get_dim(var::Variable, key::String) = _get_dim(var.dims, key)
 
-DA.@implement_diskarray Variable
 # Avoid DiskArrays.jl indexing when the parent is an Array
 Base.getindex(var::Variable{T,N,Array{T,N}}, I::AbstractUnitRange...) where {T,N} = 
     getindex(parent(var), I...)


### PR DESCRIPTION
This PR requires: https://github.com/JuliaGeo/CommonDataModel.jl/pull/35

The PR is related to the following issues https://github.com/JuliaGeo/CommonDataModel.jl/issues/32

Content:

- Bump CommonDataModel to 0.4 (Not merged yet).
- remove `@implement_diskarray`. This might not be needed. Keeping `@implement_diskarray` could help with CommonDataModel backwards compatibility 

The PR have been tested offline by

- Clone https://github.com/JuliaGeo/CommonDataModel.jl/pull/35
- Use Pkg dev to add the local repo as dependency in the test Project.toml
- Run tests.
All tests pass on my MacOS, Julia 1.11